### PR TITLE
Set IgnoreOnIsolate=true for network@.service [bnc#841651]

### DIFF
--- a/config/network@.service
+++ b/config/network@.service
@@ -3,6 +3,7 @@ Description=ifup managed network interface %i
 Requisite=network.service
 PartOf=network.service
 BindsTo=sys-subsystem-net-devices-%i.device
+IgnoreOnIsolate=true
 
 [Service]
 Type=forking


### PR DESCRIPTION
This prevents service from being stopped and interface deconfigured
on changing run levels using systemctl isolate/init N.
