### PR TITLE
ntp-runtime: cleanup tmp files (boo#1010760)

### DIFF
--- a/scripts/functions.netconfig
+++ b/scripts/functions.netconfig
@@ -263,8 +263,14 @@ netconfig_check_md5_and_move()
             log "You can find my version in ${OUTFILE}${OSUFFIX}"
             test "x$ERR_VAR" != x && eval "$ERR_VAR='${OUTFILE}${OSUFFIX}'"
         else
-            log "You can find my version in $SRCFILE ..."
-            test "x$ERR_VAR" != x && eval "$ERR_VAR='${SRCFILE}'"
+            if test "x$OSUFFIX" != x ; then
+                # backup requested + failed, set err var
+                test "x$ERR_VAR" != x && eval "$ERR_VAR='$SRCFILE'"
+            else
+                # no backup requested, delete src tmp file
+                rm --f -- "$SRCFILE"
+                test "x$ERR_VAR" != x && eval "$ERR_VAR=''"
+            fi
         fi
         RET=2
     else
@@ -279,12 +285,16 @@ netconfig_check_md5_and_move()
         fi
         rm -f "$SRCFILE"
     fi
-    rm -f "$MD5FILE"
-    {
-        test "x${NEW_ERX}" != x && \
-            echo "#${NEW_ERX}"
-        echo "$NEWMD5SUM"
-    } > "$MD5FILE"
+
+    if test $RET -eq 0 ; then
+      # update md5 when we've changed dst file
+      rm -f "$MD5FILE"
+      {
+          test "x${NEW_ERX}" != x && \
+              echo "#${NEW_ERX}"
+          echo "$NEWMD5SUM"
+      } > "$MD5FILE"
+    fi
 
     return $RET
 }

--- a/scripts/netconfig.d/ntp-runtime
+++ b/scripts/netconfig.d/ntp-runtime
@@ -41,7 +41,7 @@ debug "$PROGNAME Module called"
 NTP_SERVER_LIST=()
 
 DESTFILE="$r/var/run/ntp/servers-netconfig"
-TMP_FILE=""
+TMP_FILE="$r/var/run/ntp/.servers-netconfig.XXXXXX"
 
 function write_ntp_servers()
 {
@@ -62,10 +62,12 @@ function write_ntp_servers()
 
     local SERVERS
 
-    TMP_FILE=`mktemp -t "ntp-servers-netconfig.XXXXXX"` || return 1
+    TMP_FILE=`mktemp -- "$TMP_FILE"` || return 1
 
+    # avoid $DESTFILE.$DATE backups, useless in this case
+    test "$FORCE_REPLACE" = true && rm -f -- "$DESTFILE"
     if test ! -s "$DESTFILE" ; then
-        touch "$DESTFILE"  ; chmod 644 "$DESTFILE"
+        touch -- "$DESTFILE"  ; chmod 644 -- "$DESTFILE"
     fi
 
     # * copy dest => tmp to get the file attributes
@@ -210,7 +212,9 @@ if [ $RET -eq 1 ]; then
 elif [ $RET -eq 2 ]; then
    # user modified the config. Copy aborted
     echo "ATTENTION: You have modified $DESTFILE.  Leaving it untouched..."
-    echo "You can find my version in $TMP_FILE ..."
+    if test "x$TMP_FILE" != "x" -a -f "$TMP_FILE" ; then
+      echo "You can find my version in $TMP_FILE ..."
+    fi
 
     exit 20
 fi


### PR DESCRIPTION
When /var/run/ntp/servers-netconfig has been modified externaly,
don't try to backup or keep tmp files to show what we would do.