### PR TITLE
Fix Requires, use file requires

### DIFF
--- a/sysconfig.spec.in
+++ b/sysconfig.spec.in
@@ -48,12 +48,9 @@ BuildRequires:  pkgconfig
 Requires:       /sbin/ifup
 Requires:       /sbin/netconfig
 Requires:       sysvinit(network)
-PreReq:         %fillup_prereq
-PreReq:         fileutils
-PreReq:         gawk
-PreReq:         grep
-PreReq:         sed
-PreReq:         textutils
+Requires(post): %fillup_prereq
+Requires(post): /usr/bin/grep
+Requires(post): /usr/bin/chmod /usr/bin/mkdir /usr/bin/touch
 Recommends:     wicked-service
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
@@ -64,7 +61,9 @@ traditional "ifup" alias "netcontrol" network scripts.
 %package netconfig
 Summary:        Script to apply network provided settings
 Group:          System/Base
+Requires:       /bin/gawk
 Requires:       /bin/logger
+Requires:       /usr/bin/sed
 Requires(pre):  sysconfig = %{version}
 Provides:       /sbin/netconfig
 


### PR DESCRIPTION
Move requires to the correct (sub) packages and use consistent file requires
to allow MicroOS and Carwos to use alternate implementations of some tools.
Don't use non-existing, obsolete package names for Requires.