### PR TITLE
netconfig: only write files on a change (bsc#1176325)

### DIFF
--- a/scripts/netconfig.d/dns-bind
+++ b/scripts/netconfig.d/dns-bind
@@ -103,18 +103,24 @@ function write_named_forwarders ()
     debug "write_named_forwarders: $1 "
 
     TMP_FILE=`netconfig_mktemp "$ROOT$DESTFILE" 0644 0755` || return 3
-    dump_named_forwarders "$@" >> "$TMP_FILE" && {
-        cmp --quiet "$ROOT$DESTFILE" "$TMP_FILE"
-        changed=$?
-    } && mv -f "$TMP_FILE" "$ROOT$DESTFILE"   || {
-        rm -f -- "$TMP_FILE"
-        return 3
-    }
+    if ! dump_named_forwarders "$@" >> "$TMP_FILE" ; then
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
+    if cmp -s -- "$TMP_FILE" "$ROOT$DESTFILE"    ; then
+        rm -f -- "$TMP_FILE" # unchanged
+    elif mv -f -- "$TMP_FILE" "$ROOT$DESTFILE"   ; then
+        changed=1
+    else
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
+
     debug "dns settings written to $DESTFILE"
 
     netconfig_check_and_link "$DESTLINK" "$DESTFILE" "$ROOT"
     updated=$?
+
     test $changed -ne 0 -a $updated -eq 1 || return $updated
+    return $?
 }
 
 function get_dns_settings()

--- a/scripts/netconfig.d/dns-dnsmasq
+++ b/scripts/netconfig.d/dns-dnsmasq
@@ -93,23 +93,29 @@ EOT
 function write_dnsmasq_forwarders ()
 {
     local TMP_FILE=""
+    local changed=0
 
     test "X$1" = "X" && return 1
 
     debug "write_dnsmasq_forwarders: $1 "
 
     TMP_FILE=`netconfig_mktemp "$ROOT$RESOLV_FILE" 0644 0755` || return 3
-    dump_dnsmasq_forwarders "$@" >> "$TMP_FILE" && \
-    mv -f -- "$TMP_FILE" "$ROOT$RESOLV_FILE"    || {
-        rm -f -- "$TMP_FILE"
-        return 3
-    }
+    if ! dump_dnsmasq_forwarders "$@" >> "$TMP_FILE" ; then
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
+    if cmp -s -- "$TMP_FILE" "$ROOT$RESOLV_FILE"     ; then
+        rm -f -- "$TMP_FILE" # unchanged
+    elif mv -f -- "$TMP_FILE" "$ROOT$RESOLV_FILE"    ; then
+        changed=1
+    else
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
 
     debug "dns forwarders written to $RESOLV_FILE"
 
     ### note: this file is referenced via resolv-file=$RESOLV_FILE
     ###       in dnsmasq config files -- no need to create a link.
-    return 0
+    test $changed -ne 0
 }
 
 function get_dns_settings()

--- a/scripts/netconfig.d/dns-resolver
+++ b/scripts/netconfig.d/dns-resolver
@@ -125,6 +125,8 @@ EOT
 function write_resolv_conf()
 {
     local TMP_FILE=""
+    local changed=0
+    local updated=0
 
     #
     # empty search list is a valid value
@@ -139,15 +141,23 @@ function write_resolv_conf()
     debug "write_resolv_conf: '$1' '$2'"
 
     TMP_FILE=`netconfig_mktemp "$ROOT$DESTFILE" 0644 0755` || return 3
-    dump_resolv_conf "$@" >> "$TMP_FILE" && \
-    mv -f "$TMP_FILE" "$ROOT$DESTFILE"   || {
-        rm -f -- "$TMP_FILE"
-        return 3
-    }
+    if ! dump_resolv_conf "$@" >> "$TMP_FILE"   ; then
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
+    if cmp -s -- "$TMP_FILE" "$ROOT$DESTFILE"   ; then
+        rm -f -- "$TMP_FILE" # unchanged
+    elif mv -f -- "$TMP_FILE" "$ROOT$DESTFILE"  ; then
+        changed=1
+    else
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
 
     debug "dns settings written to $DESTFILE"
 
     netconfig_check_and_link "$DESTLINK" "$DESTFILE" "$ROOT"
+    updated=$?
+
+    test $changed -ne 0 -a $updated -eq 1 || return $updated
     return $?
 }
 

--- a/scripts/netconfig.d/nis
+++ b/scripts/netconfig.d/nis
@@ -207,19 +207,24 @@ function write_yp_conf()
     debug "write_yp_conf"
 
     TMP_FILE=`netconfig_mktemp "$ROOT$DESTFILE" 0644 0755` || return 3
-    dump_yp_conf "$@" >> "$TMP_FILE"           && {
-        cmp --quiet "$ROOT$DESTFILE" "$TMP_FILE"
-        changed=$?
-    } && mv -f -- "$TMP_FILE" "$ROOT$DESTFILE" || {
-        rm -f -- "$TMP_FILE"
-        return 3
-    }
+    if ! dump_yp_conf "$@" >> "$TMP_FILE"        ; then
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
+    if cmp -s -- "$TMP_FILE" "$ROOT$DESTFILE"    ; then
+        rm -f -- "$TMP_FILE" # unchanged
+    elif mv -f -- "$TMP_FILE" "$ROOT$DESTFILE"   ; then
+        changed=1
+    else
+            rm -f -- "$TMP_FILE" ; return 3
+    fi
 
     debug "nis settings written to $DESTFILE"
 
     netconfig_check_and_link "$DESTLINK" "$DESTFILE" "$ROOT"
     updated=$?
+
     test $changed -ne 0 -a $updated -eq 1 || return $updated
+    return $?
 }
 
 function get_uptime()

--- a/scripts/netconfig.d/ntp-runtime
+++ b/scripts/netconfig.d/ntp-runtime
@@ -95,13 +95,17 @@ function write_chrony_servers()
     debug "write_chrony_servers: $1"
 
     TMP_FILE=`netconfig_mktemp "$ROOT$CHRONY_SERVER" 0644 0755` || return 3
-    dump_chrony_servers "$@" >> "$TMP_FILE"         && {
-        cmp --quiet "$ROOT$CHRONY_SERVER" "$TMP_FILE"
-        changed=$?
-    } && mv -f -- "$TMP_FILE" "$ROOT$CHRONY_SERVER" || {
+    if ! dump_chrony_servers "$@" >> "$TMP_FILE"     ; then
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
+    if cmp -s -- "$TMP_FILE" "$ROOT$CHRONY_SERVER"   ; then
+        rm -f -- "$TMP_FILE" # unchanged
+    elif mv -f -- "$TMP_FILE" "$ROOT$CHRONY_SERVER"  ; then
+        changed=1
+    else
         rm -f -- "$TMP_FILE"
         return 3
-    }
+    fi
 
     debug "ntp servers written to $CHRONY_SERVER"
     test $changed -ne 0
@@ -122,13 +126,16 @@ function write_ntpd_servers()
     debug "write_ntpd_servers: $1"
 
     TMP_FILE=`netconfig_mktemp "$ROOT$NTPD_DESTFILE" 0644 0755` || return 3
-    dump_ntpd_servers "$@" >> "$TMP_FILE"           && {
-        cmp --quiet "$ROOT$NTPD_DESTFILE" "$TMP_FILE"
-        changed=$?
-    } && mv -f -- "$TMP_FILE" "$ROOT$NTPD_DESTFILE" || {
-        rm -f -- "$TMP_FILE"
-        return 3
-    }
+    if ! dump_ntpd_servers "$@" >> "$TMP_FILE"       ; then
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
+    if cmp -s -- "$TMP_FILE" "$ROOT$NTPD_DESTFILE"   ; then
+        rm -f -- "$TMP_FILE" # unchanged
+    elif mv -f -- "$TMP_FILE" "$ROOT$NTPD_DESTFILE"  ; then
+        changed=1
+    else
+        rm -f -- "$TMP_FILE" ; return 3
+    fi
 
     debug "ntp servers written to $NTPD_DESTFILE"
     test $changed -ne 0


### PR DESCRIPTION
Avoid e.g. dnsmasq (if running) to re-read /etc/resolv.conf and re-initialize itself without a content change.
