### PR TITLE
ppp: netconfig NetworkManager and no USEPEERDNS exclusions

### DIFF
--- a/scripts/ppp/netconfig
+++ b/scripts/ppp/netconfig
@@ -40,8 +40,16 @@ ACTION=${0#/etc/ppp/}
 #echo 1>&2 "$0: $@"
 #env  1>&2
 
-test "X$INTERFACE" = X  && exit 1
-test -x /sbin/netconfig || exit 0
+case "$6" in
+nm-*-service-*|/org/freedesktop/NetworkManager/PPP/*)
+	# NetworkManager handles it
+	exit 0
+	;;
+esac
+
+test "X$INTERFACE" = X   && exit 1
+test "X$USEPEERDNS" != X || exit 0
+test -x /sbin/netconfig  || exit 0
 
 # this assumes, there is a ifcfg file, let's look
 # if the user tried to enable verbose netconfig


### PR DESCRIPTION
If NetworkManager is being used for a ppp connection (e.g. PPP based NetworkManager VPN such a pptp, l2tp and sstp),
do not let pppd modify `/etc/resolv.conf`.

If `USEPEERDNS` is not set, no need for pppd to modify `/etc/resolv.conf`

The ppp/netconfig script changes are based on what is in Ubuntu's `/etc/ppp/ip-up.d/000resolvconf` and
`/etc/ppp/ip-down.d/000resolvconf`