### PR TITLE
netconfig: revert NM default policy change change (boo#1185882)

### DIFF
--- a/doc/netconfig.8
+++ b/doc/netconfig.8
@@ -163,11 +163,10 @@ The \fBauto\fR policy value is resolved to a policy "\fBSTATIC *\fR".
 
 .TP
 .IR NetworkManager \ is \ enabled
-The \fBauto\fR policy value is resolved to "\fBSTATIC_FALLBACK * NetworkManager\fR"
+The \fBauto\fR policy value is resolved to "\fBSTATIC_FALLBACK NetworkManager\fR"
 causing to use the NetworkManager build-in merge policy with a fallback to
 the static settings defined in netconfig variables when the NetworkManager
-does not provide any. Since version 0.84.3, the policy permits also other
-non-NetworkManager per interface settings provided by other services.
+does not provide any.
 
 Note:
 NetworkManager is not using any of the statically defined netconfig settings.

--- a/scripts/functions.netconfig
+++ b/scripts/functions.netconfig
@@ -81,7 +81,7 @@ netconfig_policy()
         # Use NetworkManager policy merged data
         #
         test "x$policy" = "xauto" && \
-            policy='STATIC_FALLBACK * NetworkManager'
+            policy='STATIC_FALLBACK NetworkManager'
     ;;
     network.service|*)
         #


### PR DESCRIPTION
With the change to the default policy, netconfig with NetworkManager
as network.service accepted settings from all services/programs
directly instead only from NetworkManager, where plugins/services
have to deliver their settings to apply them.
This reverts commit 264790a0b39775b2b509fecd38d44b5b91d5a89d and solves gh#openSUSE/sysconfig#31.