### PR TITLE
sysconfig.spec: drop legacy migration and rpm-utils

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -5,8 +5,7 @@ MAINTAINERCLEANFILES = Makefile.in
 
 SUBDIRS = hardware netconfig.d ppp
 
-sysconfig_network_scripts_SCRIPTS =	functions.rpm-utils \
-					functions.netconfig
+sysconfig_network_scripts_SCRIPTS =	functions.netconfig
 
 sbin_SCRIPTS =	netconfig
 

--- a/sysconfig.spec.in
+++ b/sysconfig.spec.in
@@ -116,7 +116,6 @@ EOF
 %ghost %{_sysconfdir}/sysconfig/network/dhcp
 %dir %{_docdir}/sysconfig
 %doc %{_docdir}/sysconfig/Contents
-%{_sysconfdir}/sysconfig/network/scripts/functions.rpm-utils
 %{_fillupdir}/sysconfig.dhcp-network
 %{_fillupdir}/sysconfig.config-network
 /sbin/rcnetwork
@@ -156,50 +155,9 @@ EOF
 %ghost %config(noreplace) %{_sysconfdir}/yp.conf
 
 %post -p /bin/bash
-#
-## we provide own, improved variant of the remove_and_set suse
-## rpm macro that is able to handle files in subdirs, and more
-. etc/sysconfig/network/scripts/functions.rpm-utils
-#
-# remove obsolete sysconfig-network specific variables
-sysconfig_remove_and_set network/config NOZEROCONF
-sysconfig_remove_and_set network/config LINKLOCAL_INTERFACES
-sysconfig_remove_and_set network/config IFPLUGD_OPTIONS
-sysconfig_remove_and_set network/config DEFAULT_BROADCAST
-sysconfig_remove_and_set network/config FORCE_PERSISTENT_NAMES
-sysconfig_remove_and_set network/config MANDATORY_DEVICES
-sysconfig_remove_and_set network/config USE_SYSLOG
-sysconfig_remove_and_set network/dhcp   DHCLIENT_BIN
-sysconfig_remove_and_set network/dhcp   DHCLIENT6_BIN
-sysconfig_remove_and_set network/dhcp   DHCLIENT_DEBUG
-sysconfig_remove_and_set network/dhcp   DHCLIENT_WAIT_LINK
-sysconfig_remove_and_set network/dhcp   DHCLIENT_USER_OPTIONS
-sysconfig_remove_and_set network/dhcp   DHCLIENT_PRIMARY_DEVICE
-sysconfig_remove_and_set network/dhcp   DHCLIENT6_USER_OPTIONS
-sysconfig_remove_and_set network/dhcp   DHCPCD_USER_OPTIONS
-sysconfig_remove_and_set network/dhcp   DHCP6C_USER_OPTIONS
-##
 %{fillup_only -dns dhcp network network}
 %{fillup_only -dns config network network}
 /sbin/ldconfig
-# remove obsolete dhcp and per interface variables
-_umask=`umask`
-for file in etc/sysconfig/network/dhcp etc/sysconfig/network/ifcfg-* ; do
-	name="${file##*\/ifcfg-}"
-	case $name in
-	(lo|""|*" "*|*~|*.old|*.rpmnew|*.rpmsave|*.scpmbackup) continue ;;
-	esac
-	case $file in
-		(*/ifcfg-*) umask 0177 ;;
-	esac
-	sysconfig_remove_and_set -b "" $file \
-		DHCLIENT_MODIFY_NTP_CONF     \
-		DHCLIENT_ADDITIONAL_OPTIONS  \
-		DHCLIENT_SCRIPT_EXE
-	umask $_umask
-done
-# be a little bit paranoid and set the correct mode even we set umask
-chmod 0600 etc/sysconfig/network/ifcfg-* 2>/dev/null || :
 
 %postun -p /sbin/ldconfig
 


### PR DESCRIPTION
Remove post hooks removing obsolete sysconfig-network (sle11)
specific variables cleanup from global and ifcfg config files
as well as the scripts/functions.rpm-utils function library
(https://github.com/openSUSE/sysconfig/issues/34).