### PR TITLE
dns-resolver: remove search limit of 6 domains

### DIFF
--- a/scripts/netconfig.d/dns-resolver
+++ b/scripts/netconfig.d/dns-resolver
@@ -90,9 +90,6 @@ EOT
             [ "x$nd" == "x$od" ] && continue 2
         done
 
-        # resolv.conf supports up to 6 domains
-        [ ${#SEARCHLIST[@]} -lt 6 ] || break
-
         SEARCHLIST=(${SEARCHLIST[@]} ${nd})
     done
 


### PR DESCRIPTION
Up to glibc 2.25, the number of search domains was limited to 6.
With glibc 2.26, this limitation was removed.