### PR TITLE
sysconfig: cleanup network and wicked dependencies

### DIFF
--- a/sysconfig.spec.in
+++ b/sysconfig.spec.in
@@ -52,14 +52,12 @@ URL:            https://github.com/openSUSE/sysconfig
 Source:         %{name}-%{version}.tar.bz2
 BuildRequires:  libtool
 BuildRequires:  pkgconfig
-Requires:       /sbin/netconfig
-Requires:       (sysvinit(network) or service(network))
 Requires(post): %fillup_prereq
 Requires(post): /usr/bin/grep
 Requires(post): /usr/bin/chmod /usr/bin/mkdir /usr/bin/touch
-%if 0%{?suse_version} >= 1550
-Suggests:       wicked-service
-%else
+%if 0%{?suse_version} < 1550
+Requires:       /sbin/netconfig
+Requires:       (sysvinit(network) or service(network))
 Recommends:     wicked-service
 %endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Actually, sysconfig does not require any network service or netconfig, but another way around.
These dependencies are rather traditional to trigger package installations, so we keep them on
already released products.