### PR TITLE
Add network/scripts directory to filelist

### DIFF
--- a/sysconfig.spec.in
+++ b/sysconfig.spec.in
@@ -171,6 +171,7 @@ EOF
 %dir %{_libexecdir}/netconfig/netconfig.d
 %{_libexecdir}/netconfig/netconfig.d/*
 %{_libexecdir}/netconfig/functions.netconfig
+%dir %{_sysconfdir}/sysconfig/network/scripts
 %{_sysconfdir}/sysconfig/network/scripts/functions.netconfig
 %{_sbindir}/netconfig
 %if !0%{?usrmerged}


### PR DESCRIPTION
This directory is no longer in the default filelist.